### PR TITLE
Previous exception: "TypeError: cannot concatenate 'str' and 'int' object

### DIFF
--- a/ratelimitcache.py
+++ b/ratelimitcache.py
@@ -43,7 +43,7 @@ class ratelimit(object):
         # memcache is only backend that can increment atomically
         try:
             # add first, to ensure the key exists
-            cache._cache.add(key, '0', time=self.expire_after())
+            cache._cache.add(key, 0, time=self.expire_after())
             cache._cache.incr(key)
         except AttributeError:
             cache.set(key, cache.get(key, 0) + 1, self.expire_after())


### PR DESCRIPTION
Previous exception: "TypeError: cannot concatenate 'str' and 'int' objects" due to initial cache value being set to '0' rather than 0. Should now be fixed.
